### PR TITLE
Fix coverage CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -117,3 +117,4 @@ jobs:
         to: ${{ github.event.repository.owner.email }},${{ github.event.pusher.email }}
         from: Gwion Coverage action
         content_type: text/html
+      if: ${{ github.repository_owner == 'fennecdjay' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,12 +18,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:
-    - name: Build Gwion
-      uses: fennecdjay/gwion-action@v1
-      with:
-        dir: .
-        ref: ${{ github.sha }}
-        run: 'true'
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Init submodules
+      run: git submodule update --init util ast
+
+    - name: Build & Test Gwion
+      run: make && make test
       env:
         USE_COVERAGE: 1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -99,7 +99,3 @@ jobs:
         git add .
         git commit -m "Update html report"
         git push origin HEAD:gh-pages
-#        git push origin --set-upstream origin gh-pages
-#        git add -f html
-#        git commit -m "Update html report"
-#        git subtree push --prefix html origin gh-pages

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,7 +53,13 @@ jobs:
         COV_NUM=${COV_TXT: : -1}
         echo $COV_NUM > gwion-coverage-report/coverage_num.txt
         sed -i 's/<html>/<script type="text\/javascript" src="..\/focus.js"><\/script><html>/' index.src_*.html
-        branch=$(basename ${{ github.event.ref }})
+        if [ "${{ github.event_name }}" == "push" ]
+        then
+          ref="${{ github.ref }}"
+        else
+          ref="${{ github.event.head.ref }}"
+        fi
+        branch=$(basename ref)
         cd gwion-coverage-report/
         bash old.sh $branch
         bash summary.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,10 +24,13 @@ jobs:
     - name: Init submodules
       run: git submodule update --init util ast
 
-    - name: Build & Test Gwion
-      run: make && make test
+    - name: Build Gwion
+      run: make
       env:
         USE_COVERAGE: 1
+        
+    - name: Test Gwion
+      run: make test
 
     - uses: actions/setup-python@v1
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,12 +17,18 @@ jobs:
         double: [0, 1]
 
     steps:
-    - name: Build Gwion
-      uses: fennecdjay/gwion-action@v1
-      with:
-        ref: ${{ github.sha }}
-        run: true
+    - name Checkout
+      uses: actions/checkout@v2
+
+    - name: Init submodules
+      run: git submodule update --init util ast
+
+    - name: Build
+      run: make
       env:
         CC: ${{ matrix.cc }}
         USE_DOUBLE: ${{ matrix.double }}
         USE_DEBUG: 1
+
+    - name: Test
+      run: make test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
         double: [0, 1]
 
     steps:
-    - name Checkout
+    - name: Checkout
       uses: actions/checkout@v2
 
     - name: Init submodules

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,11 @@ name: Linux
 
 on:
   push:
-    branches:    
+    branches:
+    - '**'
+    - '!gh-pages'
+  pull_request:
+    branches:
     - '**'
     - '!gh-pages'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ jobs:
         double: [0, 1]
 
     steps:
-    - name Checkout
+    - name: Checkout
       uses: actions/checkout@v2
 
     - name: Init submodules

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,6 +5,10 @@ on:
     branches:    
     - '**'
     - '!gh-pages'
+  pull_request:
+    branches:
+    - '**'
+    - '!gh-pages'
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,12 +17,18 @@ jobs:
         double: [0, 1]
 
     steps:
-    - name: Build Gwion
-      uses: fennecdjay/gwion-action@v1
-      with:
-        ref: ${{ github.sha }}
-        run: true
+    - name Checkout
+      uses: actions/checkout@v2
+
+    - name: Init submodules
+      run: git submodule update --init util ast
+
+    - name: Build
+      run: make
       env:
         CC: ${{ matrix.cc }}
+        USE_DOUBLE: ${{ matrix.double }}
         USE_DEBUG: 1
-        USE_DOUBLE: 1
+
+    - name: Test
+      run: make test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
         double: [0, 1]
 
     steps:
-    - name Checkout
+    - name: Checkout
       uses: actions/checkout@v2
 
     - name: Init submodules

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build
       run: make
       env:
-        CC: ${{ matrix.cc }}
+        CC: gcc
         USE_DOUBLE: ${{ matrix.double }}
         USE_DEBUG: 1
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,3 +35,5 @@ jobs:
 
     - name: Test
       run: make test
+      env:
+        BUILD_ON_WINDOWS: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,13 +16,18 @@ jobs:
         double: [0, 1]
 
     steps:
-    - name: Build Gwion
-      uses: fennecdjay/gwion-action@v1
-      with:
-        dir: .
-        ref: ${{ github.sha }}
-        run: true
+    - name Checkout
+      uses: actions/checkout@v2
+
+    - name: Init submodules
+      run: git submodule update --init util ast
+
+    - name: Build
+      run: make
       env:
-        CC: gcc
+        CC: ${{ matrix.cc }}
         USE_DOUBLE: ${{ matrix.double }}
-        BUILD_ON_WINDOWS: 1
+        USE_DEBUG: 1
+
+    - name: Test
+      run: make test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
       env:
         CC: gcc
         USE_DOUBLE: ${{ matrix.double }}
-        USE_DEBUG: 1
+        BUILD_ON_WINDOWS: 1
 
     - name: Test
       run: make test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,10 @@ on:
     branches:    
     - '**'
     - '!gh-pages'
+  pull_request:
+    branches:
+    - '**'
+    - '!gh-pages'
 
 jobs:
   build:

--- a/src/lib/ptr.c
+++ b/src/lib/ptr.c
@@ -138,7 +138,7 @@ static DTOR(ptr_struct_dtor) {
 
 static OP_CHECK(opck_ptr_scan) {
   struct TemplateScan *ts = (struct TemplateScan*)data;
-  const Type t = (Type)scan_class(env, ts->t, ts->td);
+  DECL_ON(const Type, t, = (Type)scan_class(env, ts->t, ts->td))
   const Type base = known_type(env, t->e->def->base.tmpl->call->td);
   if(isa(base, env->gwion->type[et_compound]) > 0 && !t->nspc->dtor) {
     t->nspc->dtor = new_vm_code(env->gwion->mp, NULL, SZ_INT, ae_flag_member | ae_flag_builtin, "@PtrDtor");


### PR DESCRIPTION
* Make coverage report CI use `checkout@v2`, followed by the manual build process . (previously was using `gwion-action`)
* Make "Generate report" step deduce branchname correctly for both push and PR event
* Make "Send mail" step only execute when the repository owner is `fennecdjay`