### PR TITLE
:wrench: Add command to skip benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,5 +20,6 @@ jobs:
         ORG: fennecdjay
         REPO: gwion-benchmark
       run: |
+        [ ! -z "$(git log -n1 --oneline --grep='skip ci')" ] && exit 0
         echo "{\"event_type\": \"${EVENT}\", \"client_payload\": {\"commit_info\":\"$(git log -n1 --date=format:'%D %H:%M:%S' --format='> Author: %an Date: %cd  Commit: %h')\"}}" > commit_info
         curl -d "@commit_info" -H "Content-Type: application/json" -H "Authorization: token ${{ secrets.BENCHMARK_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" "https://api.github.com/repos/${ORG}/${REPO}/dispatches"


### PR DESCRIPTION
Command will exit CI if 'skip ci' exists in the commit message.
This is detailed in Issue #209